### PR TITLE
Handling some events in safari

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -104,6 +104,17 @@
                   "maximumError": "10kb"
                 }
               ]
+            },
+            "local": {
+              "optimization": false,
+              "outputHashing": "all",
+              "sourceMap": true,
+              "extractCss": false,
+              "aot": false,
+              "namedChunks": false,
+              "extractLicenses": true,
+              "vendorChunk": false,
+              "buildOptimizer": false
             }
           }
         },
@@ -115,6 +126,13 @@
           "configurations": {
             "production": {
               "browserTarget": "ngx-pattern-demo:build:production"
+            },
+            "host": {
+              "browserTarget": "ngx-pattern-demo:build:local",
+              "port": 8080,
+              "open": true,
+              "host": "0.0.0.0",
+              "disableHostCheck": true
             }
           }
         },
@@ -167,6 +185,10 @@
           }
         }
       }
-    }},
-  "defaultProject": "ngx-pattern"
+    }
+  },
+  "defaultProject": "ngx-pattern",
+  "cli": {
+    "analytics": false
+  }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -9107,26 +9107,18 @@
           }
         },
         "tar": {
-          "version": "4.4.19",
-          "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.19.tgz",
-          "integrity": "sha512-a20gEsvHnWe0ygBY8JbxoM4w3SJdhc7ZAuxkLqh+nvNQN2IOt0B5lLgM490X5Hl8FF0dl0tOf2ewFYAlIFgzVA==",
+          "version": "4.4.13",
+          "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.13.tgz",
+          "integrity": "sha512-w2VwSrBoHa5BsSyH+KxEqeQBAllHhccyMFVHtGtdMpF4W7IRWfZjFiQceJPChOeTsSDVUpER2T8FA93pr0L+QA==",
           "dev": true,
           "requires": {
-            "chownr": "^1.1.4",
-            "fs-minipass": "^1.2.7",
-            "minipass": "^2.9.0",
-            "minizlib": "^1.3.3",
-            "mkdirp": "^0.5.5",
-            "safe-buffer": "^5.2.1",
-            "yallist": "^3.1.1"
-          },
-          "dependencies": {
-            "safe-buffer": {
-              "version": "5.2.1",
-              "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-              "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-              "dev": true
-            }
+            "chownr": "^1.1.1",
+            "fs-minipass": "^1.2.5",
+            "minipass": "^2.8.6",
+            "minizlib": "^1.2.1",
+            "mkdirp": "^0.5.0",
+            "safe-buffer": "^5.1.2",
+            "yallist": "^3.0.3"
           }
         },
         "yallist": {
@@ -12364,9 +12356,9 @@
       "dev": true
     },
     "tar": {
-      "version": "6.1.11",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-6.1.11.tgz",
-      "integrity": "sha512-an/KZQzQUkZCkuoAA64hM92X0Urb6VpRhAFllDzz44U2mcD5scmT3zBc4VgVpkugF580+DQn8eAFSyoQt0tznA==",
+      "version": "6.0.5",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-6.0.5.tgz",
+      "integrity": "sha512-0b4HOimQHj9nXNEAA7zWwMM91Zhhba3pspja6sQbgTpynOJf+bkjBnfybNYzbpLbnwXnbyB4LOREvlyXLkCHSg==",
       "dev": true,
       "requires": {
         "chownr": "^2.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9107,18 +9107,26 @@
           }
         },
         "tar": {
-          "version": "4.4.13",
-          "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.13.tgz",
-          "integrity": "sha512-w2VwSrBoHa5BsSyH+KxEqeQBAllHhccyMFVHtGtdMpF4W7IRWfZjFiQceJPChOeTsSDVUpER2T8FA93pr0L+QA==",
+          "version": "4.4.19",
+          "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.19.tgz",
+          "integrity": "sha512-a20gEsvHnWe0ygBY8JbxoM4w3SJdhc7ZAuxkLqh+nvNQN2IOt0B5lLgM490X5Hl8FF0dl0tOf2ewFYAlIFgzVA==",
           "dev": true,
           "requires": {
-            "chownr": "^1.1.1",
-            "fs-minipass": "^1.2.5",
-            "minipass": "^2.8.6",
-            "minizlib": "^1.2.1",
-            "mkdirp": "^0.5.0",
-            "safe-buffer": "^5.1.2",
-            "yallist": "^3.0.3"
+            "chownr": "^1.1.4",
+            "fs-minipass": "^1.2.7",
+            "minipass": "^2.9.0",
+            "minizlib": "^1.3.3",
+            "mkdirp": "^0.5.5",
+            "safe-buffer": "^5.2.1",
+            "yallist": "^3.1.1"
+          },
+          "dependencies": {
+            "safe-buffer": {
+              "version": "5.2.1",
+              "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+              "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+              "dev": true
+            }
           }
         },
         "yallist": {
@@ -12356,9 +12364,9 @@
       "dev": true
     },
     "tar": {
-      "version": "6.0.5",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-6.0.5.tgz",
-      "integrity": "sha512-0b4HOimQHj9nXNEAA7zWwMM91Zhhba3pspja6sQbgTpynOJf+bkjBnfybNYzbpLbnwXnbyB4LOREvlyXLkCHSg==",
+      "version": "6.1.11",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-6.1.11.tgz",
+      "integrity": "sha512-an/KZQzQUkZCkuoAA64hM92X0Urb6VpRhAFllDzz44U2mcD5scmT3zBc4VgVpkugF580+DQn8eAFSyoQt0tznA==",
       "dev": true,
       "requires": {
         "chownr": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "ng": "ng",
     "start": "ng serve",
+    "start:host": "ng serve -c host",
     "build": "ng build",
     "build-pkg": "ng build --prod ngx-pattern && npm run copy-files",
     "copy-files": "cp README.md dist/ngx-pattern/README.md && cp LICENSE dist/ngx-pattern/LICENSE",

--- a/projects/ngx-pattern/package.json
+++ b/projects/ngx-pattern/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ngx-pattern",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Directive you can use to filter allowed input with RegEx",
   "keywords": [
     "angular",
@@ -12,8 +12,8 @@
     "url" : "https://github.com/angel-vladov/ngx-pattern"
   },
   "peerDependencies": {
-    "@angular/common": "^6.0.0 || ^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0 || ^11.0.0 || ^12.0.0",
-    "@angular/core": "^6.0.0 || ^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0 || ^11.0.0 || ^12.0.0"
+    "@angular/common": "^6.0.0 || ^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0 || ^11.0.0 || ^12.0.0 || ^13.0.0",
+    "@angular/core": "^6.0.0 || ^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0 || ^11.0.0 || ^12.0.0 || ^13.0.0"
   },
   "license": "MIT",
   "author": "Angel Vladov",

--- a/projects/ngx-pattern/src/lib/ngx-pattern.directive.ts
+++ b/projects/ngx-pattern/src/lib/ngx-pattern.directive.ts
@@ -46,7 +46,7 @@ export class NgxPatternDirective implements OnChanges, OnInit, OnDestroy {
     fromEvent(this.host.nativeElement, 'touchend')
       .pipe(
         takeUntil(this.unsubscribeSubj),
-        tap((e: TouchEvent) => this.onClick(e))
+        tap((e: TouchEvent) => this.onTouchEnd(e))
       )
       .subscribe();
   }
@@ -90,7 +90,7 @@ export class NgxPatternDirective implements OnChanges, OnInit, OnDestroy {
     }
   }
 
-  onClick(ev: Event): void {
+  onTouchEnd(ev: Event): void {
     this.initSelectionValues(ev.target as HTMLInputElement);
   }
 

--- a/projects/ngx-pattern/src/lib/ngx-pattern.directive.ts
+++ b/projects/ngx-pattern/src/lib/ngx-pattern.directive.ts
@@ -42,6 +42,13 @@ export class NgxPatternDirective implements OnChanges, OnInit, OnDestroy {
         tap((e: KeyboardEvent) => this.onKeyDown(e))
       )
       .subscribe();
+
+    fromEvent(this.host.nativeElement, 'touchend')
+      .pipe(
+        takeUntil(this.unsubscribeSubj),
+        tap((e: TouchEvent) => this.onClick(e))
+      )
+      .subscribe();
   }
 
   ngOnChanges(): void {
@@ -59,8 +66,7 @@ export class NgxPatternDirective implements OnChanges, OnInit, OnDestroy {
     this.unsubscribeSubj.unsubscribe();
   }
 
-  private onKeyDown(e?: KeyboardEvent): void {
-    const input = e?.currentTarget as HTMLInputElement;
+  private initSelectionValues(input: HTMLInputElement) {
     this.lastValue = input.value || '';
     const {
       selectionStart,
@@ -72,11 +78,20 @@ export class NgxPatternDirective implements OnChanges, OnInit, OnDestroy {
     if (selectionEnd !== null) {
       this.lastSelectionEnd = selectionEnd;
     }
+  }
+
+  private onKeyDown(e?: KeyboardEvent): void {
+    const input = e?.currentTarget as HTMLInputElement;
+    this.initSelectionValues(input);
     if (this.regex && e && !e.ctrlKey && !e.metaKey && !isSpecialKey(e.key)) {
       if (!this.validWithChange(e.key)) {
         e.preventDefault();
       }
     }
+  }
+
+  onClick(ev: Event): void {
+    this.initSelectionValues(ev.target as HTMLInputElement);
   }
 
   @HostListener('input', [])

--- a/projects/ngx-pattern/src/lib/ngx-pattern.directive.ts
+++ b/projects/ngx-pattern/src/lib/ngx-pattern.directive.ts
@@ -18,13 +18,13 @@ export class NgxPatternDirective implements OnChanges, OnInit, OnDestroy {
   @Input() ngxPattern: RegExp | string;
 
   private regex: RegExp;
-  private lastSelectionStart: number;
-  private lastSelectionEnd: number;
-  private lastValue: string;
+  private lastSelectionStart = 0;
+  private lastSelectionEnd = 0;
+  private lastValue = '';
   onPasteHandler: (e: ClipboardEvent) => void;
   onKeydownHandler: (e: KeyboardEvent) => void;
 
-  constructor(@Inject(ElementRef) private host: ElementRef, @Optional() private control: NgControl) {
+  constructor(@Inject(ElementRef) private host: ElementRef, @Optional() @Inject(NgControl) private control: NgControl) {
   }
 
   ngOnInit(): void {


### PR DESCRIPTION
Safari didn't handle some events like `paste`. Event's handler attached through `HostListener` decorator, but it didn't work for some unknown reason. 
The native way like `addEventListener` works.